### PR TITLE
Relation processor update logging

### DIFF
--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/ScaffolderRelationEntityProcessor.test.ts
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/ScaffolderRelationEntityProcessor.test.ts
@@ -14,10 +14,218 @@
  * limitations under the License.
  */
 import type { Entity } from '@backstage/catalog-model';
+import type { CatalogProcessorCache } from '@backstage/plugin-catalog-node';
 
 import { ScaffolderRelationEntityProcessor } from './ScaffolderRelationEntityProcessor';
 
 describe('ScaffolderRelationEntityProcessor', () => {
+  describe('preProcessEntity', () => {
+    const processor = new ScaffolderRelationEntityProcessor();
+    const location = { type: 'url', target: 'test-url' };
+    const emit = jest.fn();
+    const mockCache: CatalogProcessorCache = {
+      get: jest.fn(),
+      set: jest.fn(),
+    };
+
+    let consoleLogSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    afterEach(() => {
+      consoleLogSpy.mockRestore();
+    });
+
+    it('should return early for non-Template entities', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'test-component' },
+      };
+
+      const result = await processor.preProcessEntity(
+        entity,
+        location,
+        emit,
+        location,
+        mockCache,
+      );
+
+      expect(result).toBe(entity);
+      expect(mockCache.get).not.toHaveBeenCalled();
+      expect(mockCache.set).not.toHaveBeenCalled();
+    });
+
+    it('should return early for Template entities without version annotation', async () => {
+      const entity: Entity = {
+        apiVersion: 'scaffolder.backstage.io/v1beta3',
+        kind: 'Template',
+        metadata: {
+          name: 'test-template',
+          annotations: {
+            'other.annotation': 'value',
+          },
+        },
+      };
+
+      const result = await processor.preProcessEntity(
+        entity,
+        location,
+        emit,
+        location,
+        mockCache,
+      );
+
+      expect(result).toBe(entity);
+      expect(mockCache.get).not.toHaveBeenCalled();
+      expect(mockCache.set).not.toHaveBeenCalled();
+    });
+
+    it('should handle Template entity with version annotation for the first time', async () => {
+      const entity: Entity = {
+        apiVersion: 'scaffolder.backstage.io/v1beta3',
+        kind: 'Template',
+        metadata: {
+          name: 'test-template',
+          annotations: {
+            'backstage.io/template-version': '1.0.0',
+          },
+        },
+      };
+
+      (mockCache.get as jest.Mock).mockResolvedValue(undefined);
+
+      await processor.preProcessEntity(
+        entity,
+        location,
+        emit,
+        location,
+        mockCache,
+      );
+
+      expect(mockCache.get).toHaveBeenCalledWith(
+        'template-version-template:default/test-template',
+      );
+      expect(mockCache.set).toHaveBeenCalledWith(
+        'template-version-template:default/test-template',
+        {
+          version: '1.0.0',
+        },
+      );
+    });
+
+    it('should detect version update when cached version is different', async () => {
+      const entity: Entity = {
+        apiVersion: 'scaffolder.backstage.io/v1beta3',
+        kind: 'Template',
+        metadata: {
+          name: 'test-template',
+          annotations: {
+            'backstage.io/template-version': '2.0.0',
+          },
+        },
+      };
+
+      const cachedData = { version: '1.0.0' };
+      (mockCache.get as jest.Mock).mockResolvedValue(cachedData);
+
+      const result = await processor.preProcessEntity(
+        entity,
+        location,
+        emit,
+        location,
+        mockCache,
+      );
+
+      expect(result).toBe(entity);
+      expect(mockCache.get).toHaveBeenCalledWith(
+        'template-version-template:default/test-template',
+      );
+      expect(mockCache.set).toHaveBeenCalledWith(
+        'template-version-template:default/test-template',
+        {
+          version: '2.0.0',
+        },
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        'Template template:default/test-template version was updated from 1.0.0 to 2.0.0',
+      );
+    });
+
+    it('should not log update when cached version is the same', async () => {
+      const entity: Entity = {
+        apiVersion: 'scaffolder.backstage.io/v1beta3',
+        kind: 'Template',
+        metadata: {
+          name: 'test-template',
+          annotations: {
+            'backstage.io/template-version': '1.0.0',
+          },
+        },
+      };
+
+      const cachedData = { version: '1.0.0' };
+      (mockCache.get as jest.Mock).mockResolvedValue(cachedData);
+
+      const result = await processor.preProcessEntity(
+        entity,
+        location,
+        emit,
+        location,
+        mockCache,
+      );
+
+      expect(result).toBe(entity);
+      expect(mockCache.get).toHaveBeenCalledWith(
+        'template-version-template:default/test-template',
+      );
+      expect(mockCache.set).toHaveBeenCalledWith(
+        'template-version-template:default/test-template',
+        {
+          version: '1.0.0',
+        },
+      );
+      expect(consoleLogSpy).not.toHaveBeenCalled();
+    });
+
+    it('should handle template with namespace', async () => {
+      const entity: Entity = {
+        apiVersion: 'scaffolder.backstage.io/v1beta3',
+        kind: 'Template',
+        metadata: {
+          name: 'test-template',
+          namespace: 'custom-namespace',
+          annotations: {
+            'backstage.io/template-version': '1.0.0',
+          },
+        },
+      };
+
+      (mockCache.get as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await processor.preProcessEntity(
+        entity,
+        location,
+        emit,
+        location,
+        mockCache,
+      );
+
+      expect(result).toBe(entity);
+      expect(mockCache.get).toHaveBeenCalledWith(
+        'template-version-template:custom-namespace/test-template',
+      );
+      expect(mockCache.set).toHaveBeenCalledWith(
+        'template-version-template:custom-namespace/test-template',
+        {
+          version: '1.0.0',
+        },
+      );
+    });
+  });
   describe('postProcessEntity', () => {
     const processor = new ScaffolderRelationEntityProcessor();
     const location = { type: 'url', target: 'test-url' };

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/templateVersionUtils.ts
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/templateVersionUtils.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { CatalogProcessorCache } from '@backstage/plugin-catalog-node';
+
+/**
+ * Cache structure for storing template version information
+ *
+ * @public
+ */
+export interface TemplateVersionCache {
+  version: string;
+}
+
+/**
+ * Handles template version checking and caching
+ *
+ * @param entityRef - The string reference of the template entity
+ * @param currentVersion - The current version of the template
+ * @param cache - The catalog processor cache
+ *
+ * @public
+ */
+export async function handleTemplateVersion(
+  entityRef: string,
+  currentVersion: string,
+  cache: CatalogProcessorCache,
+): Promise<void> {
+  const cacheKey = `template-version-${entityRef}`;
+  const cachedData = (await cache.get(cacheKey)) as
+    | TemplateVersionCache
+    | undefined;
+
+  if (cachedData) {
+    if (cachedData.version < currentVersion) {
+      console.log(
+        `Template ${entityRef} version was updated from ${cachedData.version} to ${currentVersion}`,
+      );
+      // I will emit an event here
+    }
+  }
+
+  await cache.set(cacheKey, {
+    version: currentVersion,
+  });
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This functionality enables the Scaffolder relation processor to preProcess template entities with their versions. 
How it works:
- the `preProcessEntity` function calls the `handleTemaplateVersion` function for entities which are of kind: Template and that have a `backstage.io/template-version` annotation
- the `handleTemplateVersion` function checks if there already is the version saved in cache
- if it is, and the version in cache is lower than the new one, it currently just logs the versions, but eventually it could emit an event
- at the end it writes the version into the cache

This should serve as a basis for the other functionality.
I also updated the unit tests to test this `preProcessEntity` functionality.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
