### PR TITLE
Relation processor from config

### DIFF
--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/README.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/README.md
@@ -1,6 +1,6 @@
 # Catalog Backend Module for Scaffolder Relation Catalog Processor
 
-This is an extension module to the catalog-backend plugin, providing an additional catalog entity processor that adds a new relation that depends on the `spec.scaffoldedFrom` field to link scaffolder templates and the catalog entities they generated.
+This is an extension module to the catalog-backend plugin, providing an additional catalog entity processor that adds a new relation that depends on the `spec.scaffoldedFrom` field to link scaffolder templates and the catalog entities they generated. Additionally, it includes a notification feature that automatically alerts entity owners when their scaffolder templates are updated.
 
 ## Getting Started
 
@@ -10,11 +10,17 @@ This is an extension module to the catalog-backend plugin, providing an addition
    yarn workspace backend add @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor
    ```
 
+   **Note**: If you plan to use the notification feature, you will also need to install and configure the notifications backend plugin:
+
+   ```console
+   yarn workspace backend add @backstage/plugin-notifications-backend
+   ```
+
 ### Installing on the new backend system
 
 To install this module into the [new backend system](https://backstage.io/docs/backend-system/), add the following into the `packages/backend/src/index.ts` file:
 
-```ts title="packages/backend/src/index.ts
+```ts title="packages/backend/src/index.ts"
 const backend = createBackend();
 
 // highlight-add-start
@@ -26,6 +32,13 @@ backend.add(
 // highlight-add-end
 
 backend.start();
+```
+
+**For notification feature support**, also add the notifications backend module:
+
+```ts title="packages/backend/src/index.ts"
+// Add this import for notification support
+backend.add(import('@backstage/plugin-notifications-backend'));
 ```
 
 ### Usage
@@ -45,3 +58,56 @@ These relations should also appear on the `EntityCatalogGraphView` component fro
 
 ![scaffoldedFrom Relation YAML View](./docs/example-images/scaffoldedFromYAMLView.png)
 ![scaffoldedOf Relation YAML View](./docs/example-images/scaffolderOfYAMLView.png)
+
+## Template Update Notifications
+
+This plugin includes a notification feature that automatically notifies entity owners when the scaffolder template used to create their entities has been updated to a new version. When a template update is detected, the plugin finds all entities that were scaffolded from that template (using the `spec.scaffoldedFrom` field) and notifies the owners of those entities.
+
+### Prerequisites
+
+To use the notification feature, you need to have the `@backstage/plugin-notifications-backend` Backstage plugin installed and configured.
+
+### Configuration
+
+Add the following configuration to your `app-config.yaml` to enable and customize the notification feature:
+
+```yaml
+scaffolderRelationProcessor:
+  notifications:
+    enabled: true # Set to false to disable notifications
+```
+
+Or, if you also wish to configure the notification title and description with custom text:
+
+```yaml
+scaffolderRelationProcessor:
+  notifications:
+    enabled: true # Set to false to disable notifications
+    message:
+      title: 'Custom title for ENTITY_NAME'
+      description: 'Custom description'
+```
+
+#### Configuration Options
+
+- `enabled` (boolean): Whether to enable template update notifications. Default: `false`
+- `message.title` (string): The notification title. Supports `ENTITY_NAME` template variable. Default: `'ENTITY_NAME is out of sync with template'`
+- `message.description` (string): The notification description. Supports `ENTITY_NAME` template variable. Default: `'The template used to create ENTITY_NAME has been updated to a new version. Review and update your entity to stay in sync with the template.'`
+
+#### Template Variables
+
+Both the title and description support the following template variables:
+
+- `ENTITY_NAME`: The name of the entity that was scaffolded from the updated template
+
+### Example Notification Flow
+
+1. A scaffolder template `template:default/my-service-template` is updated from version `1.0.0` to `1.1.0`
+2. The plugin detects this version change and emits a `relationProcessor.template:version_updated` event
+3. The plugin queries the catalog for all entities with `spec.scaffoldedFrom: 'template:default/my-service-template'`
+4. For each found entity, notifications are sent to all entities listed in the `ownedBy` relations
+5. The notification includes a link to the entity's catalog page and the configured message
+
+### Disabling Notifications
+
+To disable the notification feature, set `scaffolderRelationProcessor.notifications.enabled` to `false` in your configuration, or simply omit the entire `scaffolderRelationProcessor` section from your config (notifications are disabled by default).

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/README.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/README.md
@@ -65,7 +65,7 @@ This plugin includes a notification feature that automatically notifies entity o
 
 ### Prerequisites
 
-To use the notification feature, you need to have the `@backstage/plugin-notifications-backend` Backstage plugin installed and configured.
+To use the notification feature, you need to have the [`@backstage/plugin-notifications-backend`](https://github.com/backstage/backstage/tree/master/plugins/notifications-backend) Backstage plugin installed and configured.
 
 ### Configuration
 
@@ -84,21 +84,21 @@ scaffolderRelationProcessor:
   notifications:
     enabled: true # Set to false to disable notifications
     message:
-      title: 'Custom title for ENTITY_NAME'
+      title: 'Custom title for $ENTITY_NAME'
       description: 'Custom description'
 ```
 
 #### Configuration Options
 
 - `enabled` (boolean): Whether to enable template update notifications. Default: `false`
-- `message.title` (string): The notification title. Supports `ENTITY_NAME` template variable. Default: `'ENTITY_NAME is out of sync with template'`
-- `message.description` (string): The notification description. Supports `ENTITY_NAME` template variable. Default: `'The template used to create ENTITY_NAME has been updated to a new version. Review and update your entity to stay in sync with the template.'`
+- `message.title` (string): The notification title. Supports `$ENTITY_NAME` template variable. Default: `'$ENTITY_NAME is out of sync with template'`
+- `message.description` (string): The notification description. Supports `$ENTITY_NAME` template variable. Default: `'The template used to create $ENTITY_NAME has been updated to a new version. Review and update your entity to stay in sync with the template.'`
 
 #### Template Variables
 
 Both the title and description support the following template variables:
 
-- `ENTITY_NAME`: The name of the entity that was scaffolded from the updated template
+- `$ENTITY_NAME`: The name of the entity that was scaffolded from the updated template
 
 ### Example Notification Flow
 

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/config.d.ts
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/config.d.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface Config {
+  scaffolderRelationProcessor?: {
+    /**
+     * Configuration for template update notifications
+     * @visibility frontend
+     */
+    notifications?: {
+      /**
+       * Whether to enable template update notifications
+       * @default false
+       * @visibility frontend
+       */
+      enabled?: boolean;
+      /**
+       * Custom message configuration for notifications
+       * @visibility frontend
+       */
+      message?: {
+        /**
+         * The notification title. Supports $ENTITY_NAME template variable.
+         * @default '$ENTITY_NAME is out of sync with template'
+         * @visibility frontend
+         */
+        title?: string;
+        /**
+         * The notification description. Supports $ENTITY_NAME template variable.
+         * @default 'The template used to create $ENTITY_NAME has been updated to a new version. Review and update your entity to stay in sync with the template.'
+         * @visibility frontend
+         */
+        description?: string;
+      };
+    };
+  };
+}

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.5.0",
     "@backstage/cli": "^0.32.1",
+    "@backstage/config": "^1.3.2",
     "@backstage/plugin-catalog-common": "^1.1.4"
   },
   "files": [

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -57,5 +57,6 @@
   "files": [
     "config.d.ts",
     "dist"
-  ]
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/report.api.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/report.api.md
@@ -16,6 +16,20 @@ const catalogModuleScaffolderRelationProcessor: BackendFeature;
 export default catalogModuleScaffolderRelationProcessor;
 
 // @public
+export const DEFAULT_NOTIFICATION_DESCRIPTION =
+  'The template used to create ENTITY_NAME has been updated to a new version. Review and update your entity to stay in sync with the template.';
+
+// @public
+export const DEFAULT_NOTIFICATION_ENABLED = false;
+
+// @public
+export const DEFAULT_NOTIFICATION_TITLE =
+  'ENTITY_NAME is out of sync with template';
+
+// @public
+export const ENTITY_NAME_TEMPLATE_VAR = 'ENTITY_NAME';
+
+// @public
 export const RELATION_SCAFFOLDED_FROM = 'scaffoldedFrom';
 
 // @public
@@ -47,6 +61,18 @@ export class ScaffolderRelationEntityProcessor implements CatalogProcessor {
     _originLocation: LocationSpec,
     cache: CatalogProcessorCache,
   ): Promise<Entity>;
+}
+
+// @public
+export interface ScaffolderRelationProcessorConfig {
+  // (undocumented)
+  notifications?: {
+    enabled: boolean;
+    message: {
+      title: string;
+      description: string;
+    };
+  };
 }
 
 // @public

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/report.api.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/report.api.md
@@ -17,17 +17,17 @@ export default catalogModuleScaffolderRelationProcessor;
 
 // @public
 export const DEFAULT_NOTIFICATION_DESCRIPTION =
-  'The template used to create ENTITY_NAME has been updated to a new version. Review and update your entity to stay in sync with the template.';
+  'The template used to create $ENTITY_NAME has been updated to a new version. Review and update your entity to stay in sync with the template.';
 
 // @public
 export const DEFAULT_NOTIFICATION_ENABLED = false;
 
 // @public
 export const DEFAULT_NOTIFICATION_TITLE =
-  'ENTITY_NAME is out of sync with template';
+  '$ENTITY_NAME is out of sync with template';
 
 // @public
-export const ENTITY_NAME_TEMPLATE_VAR = 'ENTITY_NAME';
+export const ENTITY_NAME_TEMPLATE_VAR = '$ENTITY_NAME';
 
 // @public
 export const RELATION_SCAFFOLDED_FROM = 'scaffoldedFrom';

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/constants.ts
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/constants.ts
@@ -21,3 +21,31 @@
  */
 export const TEMPLATE_VERSION_UPDATED_TOPIC =
   'relationProcessor.template:version_updated';
+
+/**
+ * Template variable name for entity name in notification messages
+ *
+ * @public
+ */
+export const ENTITY_NAME_TEMPLATE_VAR = 'ENTITY_NAME';
+
+/**
+ * Default template update notification title
+ *
+ * @public
+ */
+export const DEFAULT_NOTIFICATION_TITLE = `${ENTITY_NAME_TEMPLATE_VAR} is out of sync with template`;
+
+/**
+ * Default template update notification description
+ *
+ * @public
+ */
+export const DEFAULT_NOTIFICATION_DESCRIPTION = `The template used to create ${ENTITY_NAME_TEMPLATE_VAR} has been updated to a new version. Review and update your entity to stay in sync with the template.`;
+
+/**
+ * Default notification enabled
+ *
+ * @public
+ */
+export const DEFAULT_NOTIFICATION_ENABLED = false;

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/constants.ts
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/constants.ts
@@ -27,7 +27,7 @@ export const TEMPLATE_VERSION_UPDATED_TOPIC =
  *
  * @public
  */
-export const ENTITY_NAME_TEMPLATE_VAR = 'ENTITY_NAME';
+export const ENTITY_NAME_TEMPLATE_VAR = '$ENTITY_NAME';
 
 /**
  * Default template update notification title

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/templateVersionUtils.test.ts
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/templateVersionUtils.test.ts
@@ -19,7 +19,15 @@ import { CatalogClient } from '@backstage/catalog-client';
 import type { NotificationService } from '@backstage/plugin-notifications-node';
 import { mockServices } from '@backstage/backend-test-utils';
 
-import { handleTemplateUpdateNotifications } from './templateVersionUtils';
+import {
+  handleTemplateUpdateNotifications,
+  readScaffolderRelationProcessorConfig,
+} from './templateVersionUtils';
+import {
+  DEFAULT_NOTIFICATION_DESCRIPTION,
+  DEFAULT_NOTIFICATION_ENABLED,
+  DEFAULT_NOTIFICATION_TITLE,
+} from './constants';
 
 // Mock external dependencies
 jest.mock('@backstage/catalog-client');
@@ -28,6 +36,15 @@ describe('templateVersionUtils', () => {
   let mockCatalogClient: jest.Mocked<CatalogClient>;
   let mockNotificationService: jest.Mocked<NotificationService>;
   let mockAuthService = mockServices.auth.mock();
+  const mockProcessorConfig = {
+    notifications: {
+      enabled: DEFAULT_NOTIFICATION_ENABLED,
+      message: {
+        title: DEFAULT_NOTIFICATION_TITLE,
+        description: DEFAULT_NOTIFICATION_DESCRIPTION,
+      },
+    },
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -95,6 +112,7 @@ describe('templateVersionUtils', () => {
         mockCatalogClient,
         mockNotificationService,
         mockAuthService,
+        mockProcessorConfig,
         payload,
       );
 
@@ -173,6 +191,7 @@ describe('templateVersionUtils', () => {
         mockCatalogClient,
         mockNotificationService,
         mockAuthService,
+        mockProcessorConfig,
         payload,
       );
 
@@ -206,6 +225,7 @@ describe('templateVersionUtils', () => {
         mockCatalogClient,
         mockNotificationService,
         mockAuthService,
+        mockProcessorConfig,
         payload,
       );
 
@@ -222,6 +242,7 @@ describe('templateVersionUtils', () => {
         mockCatalogClient,
         mockNotificationService,
         mockAuthService,
+        mockProcessorConfig,
         payload,
       );
 
@@ -244,6 +265,7 @@ describe('templateVersionUtils', () => {
         mockCatalogClient,
         mockNotificationService,
         mockAuthService,
+        mockProcessorConfig,
         payload,
       );
 
@@ -297,6 +319,7 @@ describe('templateVersionUtils', () => {
         mockCatalogClient,
         mockNotificationService,
         mockAuthService,
+        mockProcessorConfig,
         payload,
       );
 
@@ -335,6 +358,7 @@ describe('templateVersionUtils', () => {
         mockCatalogClient,
         mockNotificationService,
         mockAuthService,
+        mockProcessorConfig,
         payload,
       );
 
@@ -350,6 +374,37 @@ describe('templateVersionUtils', () => {
           link: '/catalog/default/component/simple-service',
         },
       });
+    });
+  });
+
+  describe('readScaffolderRelationProcessorConfig', () => {
+    it('should return default values when config is empty', () => {
+      const config = mockServices.rootConfig();
+
+      const result = readScaffolderRelationProcessorConfig(config);
+
+      expect(result).toEqual(mockProcessorConfig);
+    });
+
+    it('should use custom config values when provided', () => {
+      const customProcessorConfig = {
+        notifications: {
+          enabled: true,
+          message: {
+            title: 'Custom notification title',
+            description: 'Custom notification description',
+          },
+        },
+      };
+      const config = mockServices.rootConfig({
+        data: {
+          scaffolderRelationProcessor: customProcessorConfig,
+        },
+      });
+
+      const result = readScaffolderRelationProcessorConfig(config);
+
+      expect(result).toEqual(customProcessorConfig);
     });
   });
 });

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/templateVersionUtils.ts
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/templateVersionUtils.ts
@@ -125,10 +125,13 @@ async function sendNotificationsToOwners(
       const catalogUrl = createEntityCatalogUrl(entity);
 
       const entityName = entity.metadata.name;
-      const entityNameRegex = new RegExp(ENTITY_NAME_TEMPLATE_VAR, 'g');
+      const entityNameRegex = new RegExp(
+        ENTITY_NAME_TEMPLATE_VAR.replace(/\$/g, '\\$'),
+        'g',
+      );
 
       const titleReplaced =
-        config.notifications?.message.title?.replace(
+        config.notifications?.message.title.replace(
           entityNameRegex,
           entityName,
         ) || '';
@@ -138,7 +141,7 @@ async function sendNotificationsToOwners(
         titleReplaced.charAt(0).toUpperCase() + titleReplaced.slice(1);
 
       const description =
-        config.notifications?.message.description?.replace(
+        config.notifications?.message.description.replace(
           entityNameRegex,
           entityName,
         ) || '';

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/types.ts
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/types.ts
@@ -25,3 +25,18 @@ export type ScaffoldedFromSpec = {
     scaffoldedFrom: string;
   };
 };
+
+/**
+ * Configuration interface for scaffolder relation processor notifications
+ *
+ * @public
+ */
+export interface ScaffolderRelationProcessorConfig {
+  notifications?: {
+    enabled: boolean;
+    message: {
+      title: string;
+      description: string;
+    };
+  };
+}

--- a/workspaces/scaffolder-relation-processor/yarn.lock
+++ b/workspaces/scaffolder-relation-processor/yarn.lock
@@ -2638,6 +2638,7 @@ __metadata:
     "@backstage/catalog-client": "npm:^1.10.2"
     "@backstage/catalog-model": "npm:^1.7.5"
     "@backstage/cli": "npm:^0.32.1"
+    "@backstage/config": "npm:^1.3.2"
     "@backstage/plugin-catalog-common": "npm:^1.1.4"
     "@backstage/plugin-catalog-node": "npm:^1.17.0"
     "@backstage/plugin-events-node": "npm:^0.4.13"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added the final functionality for the plugin to read values from the config. All the changes are described in the updated README.md, but essentially the user can enable or disable the notifications in the config and also provide custom notification text.

**Demo 1** - when only providing the basic config
`scaffolderRelationProcessor:
  notifications:
    enabled: true`

the notification is sent with the default text:

https://github.com/user-attachments/assets/15d89c80-ff9e-47ac-86b1-8fdeb7ca5d77

Demo 2 - when providing a config with a custom message, that message is shown in the notification:


https://github.com/user-attachments/assets/53314b74-c245-481b-8bf6-ee351ab11e66

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
